### PR TITLE
Default browser used also on Linux

### DIFF
--- a/.fancom
+++ b/.fancom
@@ -20,7 +20,7 @@
 #devsuffix="temp"
 
 # Set to `1` to add random emoji file to the commit message, default: no
-#emoji=1
+emoji=1
 
 # Add all the changes made in the repo to the commit, default: no
 #addall=1
@@ -32,10 +32,10 @@
 #branchincommit=1
 
 # Skip the prefix in the commit message, default: no
-#noprefix=1
+noprefix=1
 
 # Open github compare page in the browser after succesfull push
-#opencompare=1
+opencompare=0
 
 # Github username, default: username of the owner of the current repo
 #author="authorname"

--- a/.fancom
+++ b/.fancom
@@ -20,7 +20,7 @@
 #devsuffix="temp"
 
 # Set to `1` to add random emoji file to the commit message, default: no
-emoji=1
+#emoji=1
 
 # Add all the changes made in the repo to the commit, default: no
 #addall=1
@@ -32,10 +32,10 @@ emoji=1
 #branchincommit=1
 
 # Skip the prefix in the commit message, default: no
-noprefix=1
+#noprefix=1
 
 # Open github compare page in the browser after succesfull push
-opencompare=0
+#opencompare=1
 
 # Github username, default: username of the owner of the current repo
 #author="authorname"

--- a/fancom
+++ b/fancom
@@ -111,8 +111,20 @@ if [[ -d .git ]]; then
           tempbranch=$mainbranch
           mainbranch=$comparewith
         fi
+
+        # default method of opening a browser window will be 'open' command
+        # (OSX)
+        openmetod=(open)
+
+        # but if sensible-browser is specified, use it instead
+        # (Linux)
+        which sensible-browser >/dev/null
+        if [[ $? == 0 ]]; then
+          openmethod=(sensible-browser)
+        fi
+
         # and then open the browser so we can send a pull request
-        open https://github.com/$author/$reponame/compare/$mainbranch...$tempbranch\?expand\=1
+        $openmethod https://github.com/$author/$reponame/compare/$mainbranch...$tempbranch\?expand\=1
       fi
 
     else


### PR DESCRIPTION
This patch uses `sensible-browser` to open a default browser. It still uses `open` for __OSX__
Closes #21.